### PR TITLE
Enable testing Java 7 on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,11 @@ jdk:
   - openjdk10
   - openjdk9
   - openjdk8
-  - openjdk7
+
+matrix:
+  include:
+    - jdk: openjdk7
+      install:
+        - export TARGET_JAVA_HOME=$JAVA_HOME
+        - jdk_switcher use oraclejdk8
+        - ./gradlew assemble

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,3 +16,5 @@ matrix:
         - export TARGET_JAVA_HOME=$JAVA_HOME
         - jdk_switcher use oraclejdk8
         - ./gradlew assemble
+
+before_install: export JAVA7_HOME=$(jdk_switcher home openjdk7)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,3 +27,34 @@ tasks.register<Javadoc>("internalDocs") {
     options.header("")
         .addBooleanOption("private", true)
 }
+
+// Set up Java override if configured (used to test with Java 7).
+val javaHome: String by project
+val targetJavaHome = if (hasProperty("javaHome")) javaHome else System.getenv("TARGET_JAVA_HOME")
+if (targetJavaHome != null) {
+    val javaExecutablesPath = File(targetJavaHome, "bin")
+    fun javaExecutable(execName: String): String {
+        val executable = File(javaExecutablesPath, execName)
+        require(executable.exists()) { "There is no ${execName} executable in ${javaExecutablesPath}" }
+        return executable.toString()
+    }
+
+    tasks.withType<JavaCompile>().configureEach {
+        options.apply {
+            isFork = true
+            forkOptions.javaHome = file(targetJavaHome)
+        }
+    }
+
+    tasks.withType<Javadoc>().configureEach {
+        executable = javaExecutable("javadoc")
+    }
+
+    tasks.withType<Test>().configureEach {
+        executable = javaExecutable("java")
+    }
+
+    tasks.withType<JavaExec>().configureEach {
+        executable = javaExecutable("java")
+    }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,6 +28,22 @@ tasks.register<Javadoc>("internalDocs") {
         .addBooleanOption("private", true)
 }
 
+// Set up bootstrapClasspath for Java 7.
+val java7BootClasspath: String by project
+val bootClasspath = if (hasProperty("java7BootClasspath")) java7BootClasspath else {
+    var java7Home = System.getenv("JAVA7_HOME")
+    if (java7Home != null) {
+        "${java7Home}/jre/lib/jce.jar:${java7Home}/jre/lib/rt.jar"
+    } else null
+}
+if (bootClasspath != null) {
+    tasks.withType<JavaCompile>().configureEach {
+        options.apply {
+            bootstrapClasspath = files(bootClasspath)
+        }
+    }
+}
+
 // Set up Java override if configured (used to test with Java 7).
 val javaHome: String by project
 val targetJavaHome = if (hasProperty("javaHome")) javaHome else System.getenv("TARGET_JAVA_HOME")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,6 +32,9 @@ tasks.register<Javadoc>("internalDocs") {
 val javaHome: String by project
 val targetJavaHome = if (hasProperty("javaHome")) javaHome else System.getenv("TARGET_JAVA_HOME")
 if (targetJavaHome != null) {
+    println("Target Java home set to ${targetJavaHome}")
+    println("Configuring Gradle to use forked compilation and testing")
+
     val javaExecutablesPath = File(targetJavaHome, "bin")
     fun javaExecutable(execName: String): String {
         val executable = File(javaExecutablesPath, execName)


### PR DESCRIPTION
Also configures Gradle to set `-bootclasspath`, which is necessary to compile for Java 7 with Java 8 (but AFAICT not when compiling with subsequent versions).