### PR TITLE
Add MathJax to Javadocs

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,6 +15,26 @@ java {
     targetCompatibility = JavaVersion.VERSION_1_7
 }
 
+val mathJax = "<script type='text/x-mathjax-config'>MathJax.Hub.Config({ tex2jax: { inlineMath: [ ['$','$'] ], processEscapes: true } });</script><script type='text/javascript' src='https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML'></script>"
+
+tasks.javadoc {
+    options.header("")
+        .bottom(mathJax)
+    // Add --allow-script-in-comments if available (since 1.8.0_121).
+    // See https://github.com/gradle/gradle/issues/1393
+    try {
+        var clazz = Class.forName("com.sun.tools.doclets.formats.html.ConfigurationImpl")
+        var optionLength = clazz.getDeclaredMethod("optionLength", String::class.java)
+        var result = optionLength.invoke(clazz.newInstance(), "--allow-script-in-comments") as Int
+        if (result > 0) {
+            options.header("")
+                .addBooleanOption("-allow-script-in-comments", true)
+        }
+    } catch (ignored: ClassNotFoundException) {
+    } catch (ignored: NoSuchMethodException) {
+    }
+}
+
 val docsDir: File by project
 
 tasks.register<Javadoc>("internalDocs") {
@@ -26,6 +46,20 @@ tasks.register<Javadoc>("internalDocs") {
     // StandardJavadocDocletOptions backend.
     options.header("")
         .addBooleanOption("private", true)
+    options.header("")
+        .bottom(mathJax)
+    // Add --allow-script-in-comments if available (since 1.8.0_121)
+    try {
+        var clazz = Class.forName("com.sun.tools.doclets.formats.html.ConfigurationImpl")
+        var optionLength = clazz.getDeclaredMethod("optionLength", String::class.java)
+        var result = optionLength.invoke(clazz.newInstance(), "--allow-script-in-comments") as Int
+        if (result > 0) {
+            options.header("")
+                .addBooleanOption("-allow-script-in-comments", true)
+        }
+    } catch (ignored: ClassNotFoundException) {
+    } catch (ignored: NoSuchMethodException) {
+    }
 }
 
 // Set up bootstrapClasspath for Java 7.


### PR DESCRIPTION
I plan to switch to KaTeX once the website is up, but for now this ensures that the documentation will render correctly.