### PR TITLE
Scalar arithmetic

### DIFF
--- a/src/jmh/java/cafe/cryptography/curve25519/ScalarBench.java
+++ b/src/jmh/java/cafe/cryptography/curve25519/ScalarBench.java
@@ -1,0 +1,68 @@
+package cafe.cryptography.curve25519;
+
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 2, timeUnit = TimeUnit.SECONDS)
+@Fork(1)
+@State(Scope.Benchmark)
+public class ScalarBench {
+    public byte[] aBytes;
+    public Scalar a;
+    public Scalar b;
+    public Scalar c;
+
+    @Setup
+    public void prepare() {
+        byte[] a = new byte[64];
+        byte[] b = new byte[64];
+        byte[] c = new byte[64];
+        Random r = new Random();
+        r.nextBytes(a);
+        r.nextBytes(b);
+        r.nextBytes(c);
+        this.aBytes = a;
+        this.a = Scalar.fromBytesModOrderWide(a);
+        this.b = Scalar.fromBytesModOrderWide(b);
+        this.c = Scalar.fromBytesModOrderWide(c);
+    }
+
+    @Benchmark
+    public Scalar fromBytesModOrderWide() {
+        return Scalar.fromBytesModOrderWide(this.aBytes);
+    }
+
+    @Benchmark
+    public Scalar add() {
+        return this.a.add(this.b);
+    }
+
+    @Benchmark
+    public Scalar subtract() {
+        return this.a.subtract(this.b);
+    }
+
+    @Benchmark
+    public Scalar multiply() {
+        return this.a.multiply(this.b);
+    }
+
+    @Benchmark
+    public Scalar multiplyAndAddManual() {
+        return this.a.multiply(this.b).add(this.c);
+    }
+
+    @Benchmark
+    public Scalar multiplyAndAdd() {
+        return this.a.multiplyAndAdd(this.b, this.c);
+    }
+}

--- a/src/main/java/cafe/cryptography/curve25519/Constants.java
+++ b/src/main/java/cafe/cryptography/curve25519/Constants.java
@@ -18,6 +18,28 @@ public final class Constants {
     });
 
     /**
+     * The unpacked form of the Ed25519 basepoint order.
+     */
+    static final UnpackedScalar L = UnpackedScalar.fromByteArray(BASEPOINT_ORDER.toByteArray());
+
+    /**
+     * $\ell * \text{LFACTOR} = -1 \bmod 2^29$
+     */
+    static final int LFACTOR = 0x12547e1b;
+
+    /**
+     * `R` = R % L where R = 2^261
+     */
+    static final UnpackedScalar R = new UnpackedScalar(new int[] { 0x114df9ed, 0x1a617303, 0x0f7c098c, 0x16793167,
+            0x1ffd656e, 0x1fffffff, 0x1fffffff, 0x1fffffff, 0x000fffff });
+
+    /**
+     * `RR` = (R^2) % L where R = 2^261
+     */
+    static final UnpackedScalar RR = new UnpackedScalar(new int[] { 0x0b5f9d12, 0x1e141b17, 0x158d7f3d, 0x143f3757,
+            0x1972d781, 0x042feb7c, 0x1ceec73d, 0x1e184d1e, 0x0005046d });
+
+    /**
      * Edwards $d$ value, equal to $-121665/121666 \bmod p$.
      */
     public static final FieldElement EDWARDS_D = new FieldElement(new int[] {

--- a/src/main/java/cafe/cryptography/curve25519/Scalar.java
+++ b/src/main/java/cafe/cryptography/curve25519/Scalar.java
@@ -406,8 +406,7 @@ public class Scalar {
      * @return $a * b \bmod \ell$
      */
     public Scalar multiply(final Scalar b) {
-        return new Scalar(
-                UnpackedScalar.fromByteArray(this.s).multiply(UnpackedScalar.fromByteArray(b.s)).toByteArray());
+        return this.multiplyAndAdd(b, Scalar.ZERO);
     }
 
     /**

--- a/src/main/java/cafe/cryptography/curve25519/Scalar.java
+++ b/src/main/java/cafe/cryptography/curve25519/Scalar.java
@@ -379,6 +379,38 @@ public class Scalar {
     }
 
     /**
+     * Compute $a + b \bmod \ell$.
+     *
+     * @param b the Scalar to add to this.
+     * @return $a + b \bmod \ell$
+     */
+    public Scalar add(final Scalar b) {
+        return new Scalar(UnpackedScalar.fromByteArray(this.s).add(UnpackedScalar.fromByteArray(b.s)).toByteArray());
+    }
+
+    /**
+     * Compute $a - b \bmod \ell$.
+     *
+     * @param b the Scalar to subtract from this.
+     * @return $a - b \bmod \ell$
+     */
+    public Scalar subtract(final Scalar b) {
+        return new Scalar(
+                UnpackedScalar.fromByteArray(this.s).subtract(UnpackedScalar.fromByteArray(b.s)).toByteArray());
+    }
+
+    /**
+     * Compute $a * b \bmod \ell$.
+     *
+     * @param b the Scalar to multiply with this.
+     * @return $a * b \bmod \ell$
+     */
+    public Scalar multiply(final Scalar b) {
+        return new Scalar(
+                UnpackedScalar.fromByteArray(this.s).multiply(UnpackedScalar.fromByteArray(b.s)).toByteArray());
+    }
+
+    /**
      * Compute $a * b + c \bmod \ell$.
      *
      * @param b the Scalar to multiply this by.

--- a/src/main/java/cafe/cryptography/curve25519/UnpackedScalar.java
+++ b/src/main/java/cafe/cryptography/curve25519/UnpackedScalar.java
@@ -98,7 +98,16 @@ class UnpackedScalar {
      * @return $a + b \bmod \ell$
      */
     UnpackedScalar add(final UnpackedScalar b) {
-        throw new UnsupportedOperationException();
+        int[] sum = new int[9];
+
+        int carry = 0;
+        for (int i = 0; i < 9; i++) {
+            carry = this.s[i] + b.s[i] + (carry >> 29);
+            sum[i] = carry & MASK_29_BITS;
+        }
+
+        // Subtract l if the sum is >= l
+        return new UnpackedScalar(sum).subtract(Constants.L);
     }
 
     /**
@@ -108,7 +117,130 @@ class UnpackedScalar {
      * @return $a - b \bmod \ell$
      */
     UnpackedScalar subtract(final UnpackedScalar b) {
-        throw new UnsupportedOperationException();
+        int[] difference = new int[9];
+
+        int borrow = 0;
+        for (int i = 0; i < 9; i++) {
+            borrow = this.s[i] - (b.s[i] + (borrow >>> 31));
+            difference[i] = borrow & MASK_29_BITS;
+        }
+
+        // Conditionally add l if the difference is negative
+        int underflowMask = ((borrow >>> 31) ^ 1) - 1;
+        int carry = 0;
+        for (int i = 0; i < 9; i++) {
+            carry = (carry >>> 29) + difference[i] + (Constants.L.s[i] & underflowMask);
+            difference[i] = carry & MASK_29_BITS;
+        }
+
+        return new UnpackedScalar(difference);
+    }
+
+    static long m(int a, int b) {
+        return ((long) a) * ((long) b);
+    }
+
+    /**
+     * Compute $a * b \bmod \ell$.
+     *
+     * @param val the Scalar to multiply with this.
+     * @return the unreduced limbs.
+     */
+    long[] mulInternal(final UnpackedScalar val) {
+        int[] a = this.s;
+        int[] b = val.s;
+        long[] z = new long[17];
+
+        // @formatter:off
+        z[0] = m(a[0],b[0]);                                                             // c00
+        z[1] = m(a[0],b[1]) + m(a[1],b[0]);                                              // c01
+        z[2] = m(a[0],b[2]) + m(a[1],b[1]) + m(a[2],b[0]);                               // c02
+        z[3] = m(a[0],b[3]) + m(a[1],b[2]) + m(a[2],b[1]) + m(a[3],b[0]);                // c03
+        z[4] = m(a[0],b[4]) + m(a[1],b[3]) + m(a[2],b[2]) + m(a[3],b[1]) + m(a[4],b[0]); // c04
+        z[5] =                m(a[1],b[4]) + m(a[2],b[3]) + m(a[3],b[2]) + m(a[4],b[1]); // c05
+        z[6] =                               m(a[2],b[4]) + m(a[3],b[3]) + m(a[4],b[2]); // c06
+        z[7] =                                              m(a[3],b[4]) + m(a[4],b[3]); // c07
+        z[8] =                                                            (m(a[4],b[4])) - z[3]; // c08 - c03
+
+        z[10] = z[5] - (m(a[5],b[5]));                                             // c05mc10
+        z[11] = z[6] - (m(a[5],b[6]) + m(a[6],b[5]));                              // c06mc11
+        z[12] = z[7] - (m(a[5],b[7]) + m(a[6],b[6]) + m(a[7],b[5]));               // c07mc12
+        z[13] =         m(a[5],b[8]) + m(a[6],b[7]) + m(a[7],b[6]) + m(a[8],b[5]); // c13
+        z[14] =                        m(a[6],b[8]) + m(a[7],b[7]) + m(a[8],b[6]); // c14
+        z[15] =                                       m(a[7],b[8]) + m(a[8],b[7]); // c15
+        z[16] =                                                      m(a[8],b[8]); // c16
+
+        z[ 5] = z[10] - (z[ 0]); // c05mc10 - c00
+        z[ 6] = z[11] - (z[ 1]); // c06mc11 - c01
+        z[ 7] = z[12] - (z[ 2]); // c07mc12 - c02
+        z[ 8] = z[ 8] - (z[13]); // c08mc13 - c03
+        z[ 9] = z[14] + (z[ 4]); // c14 + c04
+        z[10] = z[15] + (z[10]); // c15 + c05mc10
+        z[11] = z[16] + (z[11]); // c16 + c06mc11
+
+        int aa0 = a[0] + a[5];
+        int aa1 = a[1] + a[6];
+        int aa2 = a[2] + a[7];
+        int aa3 = a[3] + a[8];
+
+        int bb0 = b[0] + b[5];
+        int bb1 = b[1] + b[6];
+        int bb2 = b[2] + b[7];
+        int bb3 = b[3] + b[8];
+
+        z[ 5] = (m(aa0,bb0))                                                          + z[ 5]; // c20 + c05mc10 - c00
+        z[ 6] = (m(aa0,bb1 ) + m(aa1,bb0))                                            + z[ 6]; // c21 + c06mc11 - c01
+        z[ 7] = (m(aa0,bb2 ) + m(aa1,bb1 ) + m(aa2,bb0))                              + z[ 7]; // c22 + c07mc12 - c02
+        z[ 8] = (m(aa0,bb3 ) + m(aa1,bb2 ) + m(aa2,bb1 ) + m(aa3,bb0))                + z[ 8]; // c23 + c08mc13 - c03
+        z[ 9] = (m(aa0,b[4]) + m(aa1,bb3 ) + m(aa2,bb2 ) + m(aa3,bb1 ) + m(a[4],bb0)) - z[ 9]; // c24 - c14 - c04
+        z[10] = (              m(aa1,b[4]) + m(aa2,bb3 ) + m(aa3,bb2 ) + m(a[4],bb1)) - z[10]; // c25 - c15 - c05mc10
+        z[11] = (                            m(aa2,b[4]) + m(aa3,bb3 ) + m(a[4],bb2)) - z[11]; // c26 - c16 - c06mc11
+        z[12] = (                                          m(aa3,b[4]) + m(a[4],bb3)) - z[12]; // c27 - c07mc12
+        // @formatter:on
+
+        return z;
+    }
+
+    /**
+     * Compute $\text{limbs}/R \bmod \ell$, where R is the Montgomery modulus 2^261.
+     *
+     * @param limbs the value to reduce.
+     * @return $\text{limbs}/R \bmod \ell$
+     */
+    static UnpackedScalar montgomeryReduce(long[] limbs) {
+        // Note: l5,l6,l7 are zero, so their multiplies can be skipped
+        int[] l = Constants.L.s;
+        long sum, carry;
+        int n0, n1, n2, n3, n4, n5, n6, n7, n8;
+        int[] r = new int[9];
+
+        // The first half computes the Montgomery adjustment factor n, and begins adding
+        // n*l to make limbs divisible by R
+        // @formatter:off
+        sum = (        limbs[ 0]                                                                                                        ); n0 = (int) (((sum & 0xffffffff) * Constants.LFACTOR) & MASK_29_BITS); carry = (sum + m(n0,l[0])) >>> 29;
+        sum = (carry + limbs[ 1] + m(n0,l[1])                                                                                           ); n1 = (int) (((sum & 0xffffffff) * Constants.LFACTOR) & MASK_29_BITS); carry = (sum + m(n1,l[0])) >>> 29;
+        sum = (carry + limbs[ 2] + m(n0,l[2]) + m(n1,l[1])                                                                              ); n2 = (int) (((sum & 0xffffffff) * Constants.LFACTOR) & MASK_29_BITS); carry = (sum + m(n2,l[0])) >>> 29;
+        sum = (carry + limbs[ 3] + m(n0,l[3]) + m(n1,l[2]) + m(n2,l[1])                                                                 ); n3 = (int) (((sum & 0xffffffff) * Constants.LFACTOR) & MASK_29_BITS); carry = (sum + m(n3,l[0])) >>> 29;
+        sum = (carry + limbs[ 4] + m(n0,l[4]) + m(n1,l[3]) + m(n2,l[2]) + m(n3,l[1])                                                    ); n4 = (int) (((sum & 0xffffffff) * Constants.LFACTOR) & MASK_29_BITS); carry = (sum + m(n4,l[0])) >>> 29;
+        sum = (carry + limbs[ 5]              + m(n1,l[4]) + m(n2,l[3]) + m(n3,l[2]) + m(n4,l[1])                                       ); n5 = (int) (((sum & 0xffffffff) * Constants.LFACTOR) & MASK_29_BITS); carry = (sum + m(n5,l[0])) >>> 29;
+        sum = (carry + limbs[ 6]                           + m(n2,l[4]) + m(n3,l[3]) + m(n4,l[2]) + m(n5,l[1])                          ); n6 = (int) (((sum & 0xffffffff) * Constants.LFACTOR) & MASK_29_BITS); carry = (sum + m(n6,l[0])) >>> 29;
+        sum = (carry + limbs[ 7]                                        + m(n3,l[4]) + m(n4,l[3]) + m(n5,l[2]) + m(n6,l[1])             ); n7 = (int) (((sum & 0xffffffff) * Constants.LFACTOR) & MASK_29_BITS); carry = (sum + m(n7,l[0])) >>> 29;
+        sum = (carry + limbs[ 8] + m(n0,l[8])                                        + m(n4,l[4]) + m(n5,l[3]) + m(n6,l[2]) + m(n7,l[1])); n8 = (int) (((sum & 0xffffffff) * Constants.LFACTOR) & MASK_29_BITS); carry = (sum + m(n8,l[0])) >>> 29;
+
+        // limbs is divisible by R now, so we can divide by R by simply storing the upper half as the result
+        sum = (carry + limbs[ 9]              + m(n1,l[8])                                        + m(n5,l[4]) + m(n6,l[3]) + m(n7,l[2]) + m(n8,l[1])); r[0] = (int) (sum & MASK_29_BITS); carry = sum >>> 29;
+        sum = (carry + limbs[10]                           + m(n2,l[8])                                        + m(n6,l[4]) + m(n7,l[3]) + m(n8,l[2])); r[1] = (int) (sum & MASK_29_BITS); carry = sum >>> 29;
+        sum = (carry + limbs[11]                                        + m(n3,l[8])                                        + m(n7,l[4]) + m(n8,l[3])); r[2] = (int) (sum & MASK_29_BITS); carry = sum >>> 29;
+        sum = (carry + limbs[12]                                                     + m(n4,l[8])                                        + m(n8,l[4])); r[3] = (int) (sum & MASK_29_BITS); carry = sum >>> 29;
+        sum = (carry + limbs[13]                                                                  + m(n5,l[8])                                       ); r[4] = (int) (sum & MASK_29_BITS); carry = sum >>> 29;
+        sum = (carry + limbs[14]                                                                               + m(n6,l[8])                          ); r[5] = (int) (sum & MASK_29_BITS); carry = sum >>> 29;
+        sum = (carry + limbs[15]                                                                                            + m(n7,l[8])             ); r[6] = (int) (sum & MASK_29_BITS); carry = sum >>> 29;
+        sum = (carry + limbs[16]                                                                                                         + m(n8,l[8])); r[7] = (int) (sum & MASK_29_BITS); carry = sum >>> 29;
+        r[8] = (int) (carry & 0xffffffff);
+        // @formatter:on
+
+        // Result may be >= l, so attempt to subtract l
+        return new UnpackedScalar(r).subtract(Constants.L);
     }
 
     /**
@@ -118,6 +250,7 @@ class UnpackedScalar {
      * @return $a * b \bmod \ell$
      */
     UnpackedScalar multiply(final UnpackedScalar b) {
-        throw new UnsupportedOperationException();
+        UnpackedScalar ab = UnpackedScalar.montgomeryReduce(this.mulInternal(b));
+        return UnpackedScalar.montgomeryReduce(ab.mulInternal(Constants.RR));
     }
 }

--- a/src/main/java/cafe/cryptography/curve25519/UnpackedScalar.java
+++ b/src/main/java/cafe/cryptography/curve25519/UnpackedScalar.java
@@ -15,6 +15,82 @@ class UnpackedScalar {
         this.s = s;
     }
 
+    static final int MASK_29_BITS = (1 << 29) - 1;
+    static final int MASK_24_BITS = (1 << 24) - 1;
+
+    /**
+     * Unpack a 32 byte / 256 bit scalar into 9 29-bit limbs.
+     */
+    static UnpackedScalar fromByteArray(final byte[] input) {
+        if (input.length != 32) {
+            throw new IllegalArgumentException("Input must by 32 bytes");
+        }
+
+        int[] words = new int[8];
+        for (int i = 0; i < 8; i++) {
+            for (int j = 0; j < 4; j++) {
+                words[i] |= ((input[(i * 4) + j]) & 0xff) << (j * 8);
+            }
+        }
+
+        int[] s = new int[9];
+
+        s[0] = (words[0] & MASK_29_BITS);
+        s[1] = (((words[0] >>> 29) | (words[1] << 3)) & MASK_29_BITS);
+        s[2] = (((words[1] >>> 26) | (words[2] << 6)) & MASK_29_BITS);
+        s[3] = (((words[2] >>> 23) | (words[3] << 9)) & MASK_29_BITS);
+        s[4] = (((words[3] >>> 20) | (words[4] << 12)) & MASK_29_BITS);
+        s[5] = (((words[4] >>> 17) | (words[5] << 15)) & MASK_29_BITS);
+        s[6] = (((words[5] >>> 14) | (words[6] << 18)) & MASK_29_BITS);
+        s[7] = (((words[6] >>> 11) | (words[7] << 21)) & MASK_29_BITS);
+        s[8] = ((words[7] >>> 8) & MASK_24_BITS);
+
+        return new UnpackedScalar(s);
+    }
+
+    /**
+     * Pack the limbs of this UnpackedScalar into 32 bytes.
+     */
+    byte[] toByteArray() {
+        byte[] result = new byte[32];
+
+        // All limbs are 29 bits, but let's use the unsigned right shift anyway.
+        result[0] = (byte) (this.s[0] >>> 0);
+        result[1] = (byte) (this.s[0] >>> 8);
+        result[2] = (byte) (this.s[0] >>> 16);
+        result[3] = (byte) ((this.s[0] >>> 24) | (this.s[1] << 5));
+        result[4] = (byte) (this.s[1] >>> 3);
+        result[5] = (byte) (this.s[1] >>> 11);
+        result[6] = (byte) (this.s[1] >>> 19);
+        result[7] = (byte) ((this.s[1] >>> 27) | (this.s[2] << 2));
+        result[8] = (byte) (this.s[2] >>> 6);
+        result[9] = (byte) (this.s[2] >>> 14);
+        result[10] = (byte) ((this.s[2] >>> 22) | (this.s[3] << 7));
+        result[11] = (byte) (this.s[3] >>> 1);
+        result[12] = (byte) (this.s[3] >>> 9);
+        result[13] = (byte) (this.s[3] >>> 17);
+        result[14] = (byte) ((this.s[3] >>> 25) | (this.s[4] << 4));
+        result[15] = (byte) (this.s[4] >>> 4);
+        result[16] = (byte) (this.s[4] >>> 12);
+        result[17] = (byte) (this.s[4] >>> 20);
+        result[18] = (byte) ((this.s[4] >>> 28) | (this.s[5] << 1));
+        result[19] = (byte) (this.s[5] >>> 7);
+        result[20] = (byte) (this.s[5] >>> 15);
+        result[21] = (byte) ((this.s[5] >>> 23) | (this.s[6] << 6));
+        result[22] = (byte) (this.s[6] >>> 2);
+        result[23] = (byte) (this.s[6] >>> 10);
+        result[24] = (byte) (this.s[6] >>> 18);
+        result[25] = (byte) ((this.s[6] >>> 26) | (this.s[7] << 3));
+        result[26] = (byte) (this.s[7] >>> 5);
+        result[27] = (byte) (this.s[7] >>> 13);
+        result[28] = (byte) (this.s[7] >>> 21);
+        result[29] = (byte) (this.s[8] >>> 0);
+        result[30] = (byte) (this.s[8] >>> 8);
+        result[31] = (byte) (this.s[8] >>> 16);
+
+        return result;
+    }
+
     /**
      * Compute $a + b \bmod \ell$.
      *

--- a/src/main/java/cafe/cryptography/curve25519/UnpackedScalar.java
+++ b/src/main/java/cafe/cryptography/curve25519/UnpackedScalar.java
@@ -1,0 +1,47 @@
+package cafe.cryptography.curve25519;
+
+/**
+ * Represents an element in ℤ/lℤ as 9 29-bit limbs.
+ */
+class UnpackedScalar {
+    static final UnpackedScalar ZERO = new UnpackedScalar(new int[] { 0, 0, 0, 0, 0, 0, 0, 0, 0 });
+
+    final int[] s;
+
+    UnpackedScalar(final int[] s) {
+        if (s.length != 9) {
+            throw new IllegalArgumentException("Invalid radix-2^29 representation");
+        }
+        this.s = s;
+    }
+
+    /**
+     * Compute $a + b \bmod \ell$.
+     *
+     * @param b the Scalar to add to this.
+     * @return $a + b \bmod \ell$
+     */
+    UnpackedScalar add(final UnpackedScalar b) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Compute $a - b \bmod \ell$.
+     *
+     * @param b the Scalar to subtract from this.
+     * @return $a - b \bmod \ell$
+     */
+    UnpackedScalar subtract(final UnpackedScalar b) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Compute $a * b \bmod \ell$.
+     *
+     * @param b the Scalar to multiply with this.
+     * @return $a * b \bmod \ell$
+     */
+    UnpackedScalar multiply(final UnpackedScalar b) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/src/test/java/cafe/cryptography/curve25519/ScalarTest.java
+++ b/src/test/java/cafe/cryptography/curve25519/ScalarTest.java
@@ -53,6 +53,8 @@ public class ScalarTest {
         Scalar r = new Scalar(TV1_R);
         Scalar S = new Scalar(TV1_S);
         assertThat(h.multiplyAndAdd(a, r), is(equalTo(S)));
+        assertThat(h.multiply(a).add(r), is(equalTo(S)));
+        assertThat(h.multiply(a), is(equalTo(S.subtract(r))));
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/src/test/java/cafe/cryptography/curve25519/ScalarTest.java
+++ b/src/test/java/cafe/cryptography/curve25519/ScalarTest.java
@@ -9,6 +9,53 @@ import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.junit.Assert.assertThat;
 
 public class ScalarTest {
+    /**
+     * x =
+     * 2238329342913194256032495932344128051776374960164957527413114840482143558222
+     */
+    static final Scalar X = new Scalar(
+            Utils.hexToBytes("4e5ab4345d4708845913b4641bc27d5252a585101bcc4244d449f4a879d9f204"));
+
+    /**
+     * 1/x =
+     * 6859937278830797291664592131120606308688036382723378951768035303146619657244
+     */
+    static final Scalar XINV = new Scalar(
+            Utils.hexToBytes("1cdc17fce0e9a5bbd9247e56bb016347bbba31edd5a9bb96d50bcd7a3f962a0f"));
+
+    /**
+     * y =
+     * 2592331292931086675770238855846338635550719849568364935475441891787804997264
+     */
+    static final Scalar Y = new Scalar(
+            Utils.hexToBytes("907633fe1c4b66a4a28d2dd7678386c353d0de5455d4fc9de8ef7ac31f35bb05"));
+
+    /**
+     * x*y =
+     * 5690045403673944803228348699031245560686958845067437804563560795922180092780
+     */
+    static final Scalar X_TIMES_Y = new Scalar(
+            Utils.hexToBytes("6c3374a1894f62210aaa2fe186a6f92ce0aa75c2779581c295fc08179a73940c"));
+
+    /**
+     * sage: l = 2^252 + 27742317777372353535851937790883648493 sage: big = 2^256 -
+     * 1 sage: repr((big % l).digits(256))
+     */
+    static final Scalar CANONICAL_2_256_MINUS_1 = new Scalar(
+            Utils.hexToBytes("1c95988d7431ecd670cf7d73f45befc6feffffffffffffffffffffffffffff0f"));
+
+    static final Scalar A_SCALAR = new Scalar(
+            Utils.hexToBytes("1a0e978a90f6622d3747023f8ad8264da758aa1b88e040d1589e7b7f2376ef09"));
+
+    static final byte[] A_NAF = new byte[] { 0, 13, 0, 0, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, -9, 0, 0, 0, 0, -11, 0, 0,
+            0, 0, 3, 0, 0, 0, 0, 1, 0, 0, 0, 0, 9, 0, 0, 0, 0, -5, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 11, 0, 0, 0, 0, 11,
+            0, 0, 0, 0, 0, -9, 0, 0, 0, 0, 0, -3, 0, 0, 0, 0, 9, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, -1, 0, 0, 0, 0, 0,
+            9, 0, 0, 0, 0, -15, 0, 0, 0, 0, -7, 0, 0, 0, 0, -9, 0, 0, 0, 0, 0, 5, 0, 0, 0, 0, 13, 0, 0, 0, 0, 0, -3, 0,
+            0, 0, 0, -11, 0, 0, 0, 0, -7, 0, 0, 0, 0, -13, 0, 0, 0, 0, 11, 0, 0, 0, 0, -9, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0,
+            0, -15, 0, 0, 0, 0, 1, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0, 13, 0, 0, 0, 0, 0, 0, 11, 0,
+            0, 0, 0, 0, 15, 0, 0, 0, 0, 0, -9, 0, 0, 0, 0, 0, 0, 0, -1, 0, 0, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, -15, 0,
+            0, 0, 0, 0, 15, 0, 0, 0, 0, 15, 0, 0, 0, 0, 15, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0 };
+
     @Test
     public void packageConstructorDoesNotThrowOnValid() {
         byte[] s = new byte[32];
@@ -31,6 +78,25 @@ public class ScalarTest {
     @Test(expected = IllegalArgumentException.class)
     public void packageConstructorThrowsOnTooLong() {
         new Scalar(new byte[33]);
+    }
+
+    @Test
+    public void reduceWide() {
+        Scalar biggest = Scalar.fromBytesModOrderWide(Utils.hexToBytes(
+                "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff0000000000000000000000000000000000000000000000000000000000000000"));
+        assertThat(biggest, is(CANONICAL_2_256_MINUS_1));
+    }
+
+    @Test
+    public void multiply() {
+        assertThat(X.multiply(Y), is(X_TIMES_Y));
+        assertThat(X_TIMES_Y.multiply(XINV), is(Y));
+    }
+
+    @Test
+    public void nonAdjacentForm() {
+        byte[] naf = A_SCALAR.nonAdjacentForm();
+        assertThat(naf, is(A_NAF));
     }
 
     // Example from RFC 8032 test case 1

--- a/src/test/java/cafe/cryptography/curve25519/UnpackedScalarTest.java
+++ b/src/test/java/cafe/cryptography/curve25519/UnpackedScalarTest.java
@@ -1,0 +1,96 @@
+package cafe.cryptography.curve25519;
+
+import org.junit.*;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.junit.Assert.assertThat;
+
+public class UnpackedScalarTest {
+    /**
+     * Note: x is 2^253-1 which is slightly larger than the largest scalar produced
+     * by this implementation (l-1), and should verify there are no overflows for
+     * valid scalars
+     *
+     * x = 2^253-1 =
+     * 14474011154664524427946373126085988481658748083205070504932198000989141204991
+     *
+     * x =
+     * 7237005577332262213973186563042994240801631723825162898930247062703686954002
+     * mod l
+     *
+     * x =
+     * 5147078182513738803124273553712992179887200054963030844803268920753008712037*R
+     * mod l in Montgomery form
+     */
+    static final UnpackedScalar X = new UnpackedScalar(new int[] { 0x1fffffff, 0x1fffffff, 0x1fffffff, 0x1fffffff,
+            0x1fffffff, 0x1fffffff, 0x1fffffff, 0x1fffffff, 0x001fffff });
+
+    /**
+     * x^2 =
+     * 3078544782642840487852506753550082162405942681916160040940637093560259278169
+     * mod l
+     */
+    static final UnpackedScalar XX = new UnpackedScalar(new int[] { 0x00217559, 0x000b3401, 0x103ff43b, 0x1462a62c,
+            0x1d6f9f38, 0x18e7a42f, 0x09a3dcee, 0x008dbe18, 0x0006ce65 });
+
+    /**
+     * y =
+     * 6145104759870991071742105800796537629880401874866217824609283457819451087098
+     */
+    static final UnpackedScalar Y = new UnpackedScalar(new int[] { 0x1e1458fa, 0x165ba838, 0x1d787b36, 0x0e577f3a,
+            0x1d2baf06, 0x1d689a19, 0x1fff3047, 0x117704ab, 0x000d9601 });
+
+    /**
+     * x*y = 36752150652102274958925982391442301741
+     */
+    static final UnpackedScalar XY = new UnpackedScalar(new int[] { 0x0ba7632d, 0x017736bb, 0x15c76138, 0x0c69daa1,
+            0x000001ba, 0x00000000, 0x00000000, 0x00000000, 0x00000000 });
+
+    /**
+     * a =
+     * 2351415481556538453565687241199399922945659411799870114962672658845158063753
+     */
+    static final UnpackedScalar A = new UnpackedScalar(new int[] { 0x07b3be89, 0x02291b60, 0x14a99f03, 0x07dc3787,
+            0x0a782aae, 0x16262525, 0x0cfdb93f, 0x13f5718d, 0x000532da });
+
+    /**
+     * b =
+     * 4885590095775723760407499321843594317911456947580037491039278279440296187236
+     */
+    static final UnpackedScalar B = new UnpackedScalar(new int[] { 0x15421564, 0x1e69fd72, 0x093d9692, 0x161785be,
+            0x1587d69f, 0x09d9dada, 0x130246c0, 0x0c0a8e72, 0x000acd25 });
+
+    /**
+     * a+b = 0
+     */
+
+    /**
+     * a-b =
+     * 4702830963113076907131374482398799845891318823599740229925345317690316127506
+     */
+    static final UnpackedScalar AB = new UnpackedScalar(new int[] { 0x0f677d12, 0x045236c0, 0x09533e06, 0x0fb86f0f,
+            0x14f0555c, 0x0c4c4a4a, 0x19fb727f, 0x07eae31a, 0x000a65b5 });
+
+    @Test
+    public void add() {
+        assertThat(A.add(B).s, is(UnpackedScalar.ZERO.s));
+    }
+
+    @Test
+    public void subtract() {
+        assertThat(A.subtract(B).s, is(AB.s));
+    }
+
+    @Test
+    public void multiply() {
+        assertThat(X.multiply(Y).s, is(XY.s));
+    }
+
+    @Test
+    public void multiplyMax() {
+        assertThat(X.multiply(X).s, is(XX.s));
+    }
+}

--- a/src/test/java/cafe/cryptography/curve25519/UnpackedScalarTest.java
+++ b/src/test/java/cafe/cryptography/curve25519/UnpackedScalarTest.java
@@ -75,6 +75,14 @@ public class UnpackedScalarTest {
             0x14f0555c, 0x0c4c4a4a, 0x19fb727f, 0x07eae31a, 0x000a65b5 });
 
     @Test
+    public void unpackThenPack() {
+        assertThat(UnpackedScalar.fromByteArray(ScalarTest.TV1_R).toByteArray(), is(ScalarTest.TV1_R));
+        assertThat(UnpackedScalar.fromByteArray(ScalarTest.TV1_H).toByteArray(), is(ScalarTest.TV1_H));
+        assertThat(UnpackedScalar.fromByteArray(ScalarTest.TV1_A).toByteArray(), is(ScalarTest.TV1_A));
+        assertThat(UnpackedScalar.fromByteArray(ScalarTest.TV1_S).toByteArray(), is(ScalarTest.TV1_S));
+    }
+
+    @Test
     public void add() {
         assertThat(A.add(B).s, is(UnpackedScalar.ZERO.s));
     }

--- a/src/test/java/cafe/cryptography/curve25519/UnpackedScalarTest.java
+++ b/src/test/java/cafe/cryptography/curve25519/UnpackedScalarTest.java
@@ -83,6 +83,11 @@ public class UnpackedScalarTest {
     }
 
     @Test
+    public void addLToZero() {
+        assertThat(UnpackedScalar.ZERO.add(Constants.L).s, is(UnpackedScalar.ZERO.s));
+    }
+
+    @Test
     public void add() {
         assertThat(A.add(B).s, is(UnpackedScalar.ZERO.s));
     }


### PR DESCRIPTION
Includes 29-bit arithmetic ported from curve25519-dalek, which we use for addition, subtraction, and decoding / reduction.

Multiplication and multiply-and-add use the existing arithmetic extracted from ed25519-java, as it is over twice as fast.