### PR TITLE
Scalar immutability

### DIFF
--- a/src/main/java/cafe/cryptography/curve25519/Scalar.java
+++ b/src/main/java/cafe/cryptography/curve25519/Scalar.java
@@ -35,7 +35,8 @@ public class Scalar {
         if (s.length != 32 || (((s[31] >> 7) & 0x01) != 0)) {
             throw new IllegalArgumentException("Invalid scalar representation");
         }
-        this.s = s;
+        // Store a copy to prevent interior mutability
+        this.s = Arrays.copyOf(s, s.length);
     }
 
     /**
@@ -385,7 +386,8 @@ public class Scalar {
      * @return the 32-byte little-endian encoding of this Scalar.
      */
     public byte[] toByteArray() {
-        return s;
+        // Return a copy to prevent interior mutability
+        return Arrays.copyOf(this.s, this.s.length);
     }
 
     /**

--- a/src/test/java/cafe/cryptography/curve25519/ScalarTest.java
+++ b/src/test/java/cafe/cryptography/curve25519/ScalarTest.java
@@ -92,6 +92,38 @@ public class ScalarTest {
     }
 
     @Test
+    public void packageConstructorPreventsMutability() {
+        // Create byte array representing a zero scalar
+        byte[] bytes = new byte[32];
+
+        // Create a scalar from bytes
+        Scalar s = new Scalar(bytes);
+        assertThat(s, is(Scalar.ZERO));
+
+        // Modify the bytes
+        bytes[0] = 1;
+
+        // The scalar should be unaltered
+        assertThat(s, is(Scalar.ZERO));
+    }
+
+    @Test
+    public void toByteArrayPreventsMutability() {
+        // Create a zero scalar
+        Scalar s = new Scalar(new byte[32]);
+        assertThat(s, is(Scalar.ZERO));
+
+        // Grab the scalar as bytes
+        byte[] bytes = s.toByteArray();
+
+        // Modify the bytes
+        bytes[0] = 1;
+
+        // The scalar should be unaltered
+        assertThat(s, is(Scalar.ZERO));
+    }
+
+    @Test
     public void reduce() {
         Scalar biggest = Scalar.fromBytesModOrder(
                 Utils.hexToBytes("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"));


### PR DESCRIPTION
This prevents a user from constructing a Scalar and then arbitrarily turning it into a different scalar, possibly breaking required invariants.