### PR TITLE
Implement Serializable for scalars and group elements

### DIFF
--- a/src/main/java/cafe/cryptography/curve25519/CompressedEdwardsY.java
+++ b/src/main/java/cafe/cryptography/curve25519/CompressedEdwardsY.java
@@ -12,7 +12,6 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.ObjectStreamException;
 import java.io.Serializable;
-import java.lang.reflect.Field;
 import java.util.Arrays;
 
 import cafe.cryptography.subtle.ConstantTime;
@@ -32,7 +31,7 @@ public class CompressedEdwardsY implements Serializable {
     /**
      * The encoded point.
      */
-    private transient final byte[] data;
+    private transient byte[] data;
 
     public CompressedEdwardsY(byte[] data) {
         if (data.length != 32) {
@@ -54,26 +53,7 @@ public class CompressedEdwardsY implements Serializable {
     private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
         byte[] encoded = new byte[32];
         in.readFully(encoded);
-
-        // CompressedEdwardsY fields are all final, so we need to carefully set them.
-        Field fieldData = null;
-        try {
-            fieldData = CompressedEdwardsY.class.getDeclaredField("data");
-            fieldData.setAccessible(true);
-            fieldData.set(this, encoded);
-        } catch (NoSuchFieldException nsfe) {
-            // Should never occur, but just in case...
-            throw new IOException(nsfe);
-        } catch (IllegalAccessException iae) {
-            // Could occur if a SecurityManager is enabled.
-            throw new IOException(iae);
-        } finally {
-            // Ensure the fields are always set back to final if there is a chance
-            // they might have been made accessible.
-            if (fieldData != null) {
-                fieldData.setAccessible(false);
-            }
-        }
+        this.data = encoded;
     }
 
     @SuppressWarnings("unused")

--- a/src/main/java/cafe/cryptography/curve25519/CompressedEdwardsY.java
+++ b/src/main/java/cafe/cryptography/curve25519/CompressedEdwardsY.java
@@ -6,6 +6,13 @@
 
 package cafe.cryptography.curve25519;
 
+import java.io.IOException;
+import java.io.InvalidObjectException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.ObjectStreamException;
+import java.io.Serializable;
+import java.lang.reflect.Field;
 import java.util.Arrays;
 
 import cafe.cryptography.subtle.ConstantTime;
@@ -19,17 +26,59 @@ import cafe.cryptography.subtle.ConstantTime;
  * The first 255 bits of a CompressedEdwardsY represent the $y$-coordinate. The
  * high bit of the 32nd byte represents the sign of $x$.
  */
-public class CompressedEdwardsY {
+public class CompressedEdwardsY implements Serializable {
+    private static final long serialVersionUID = 1L;
+
     /**
      * The encoded point.
      */
-    private final byte[] data;
+    private transient final byte[] data;
 
     public CompressedEdwardsY(byte[] data) {
         if (data.length != 32) {
             throw new IllegalArgumentException("Invalid CompressedEdwardsY encoding");
         }
         this.data = data;
+    }
+
+    /**
+     * Overrides class serialization to use the canonical encoded format.
+     */
+    private void writeObject(ObjectOutputStream out) throws IOException {
+        out.write(this.toByteArray());
+    }
+
+    /**
+     * Overrides class serialization to use the canonical encoded format.
+     */
+    private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
+        byte[] encoded = new byte[32];
+        in.readFully(encoded);
+
+        // CompressedEdwardsY fields are all final, so we need to carefully set them.
+        Field fieldData = null;
+        try {
+            fieldData = CompressedEdwardsY.class.getDeclaredField("data");
+            fieldData.setAccessible(true);
+            fieldData.set(this, encoded);
+        } catch (NoSuchFieldException nsfe) {
+            // Should never occur, but just in case...
+            throw new IOException(nsfe);
+        } catch (IllegalAccessException iae) {
+            // Could occur if a SecurityManager is enabled.
+            throw new IOException(iae);
+        } finally {
+            // Ensure the fields are always set back to final if there is a chance
+            // they might have been made accessible.
+            if (fieldData != null) {
+                fieldData.setAccessible(false);
+            }
+        }
+    }
+
+    @SuppressWarnings("unused")
+    private void readObjectNoData() throws ObjectStreamException {
+        throw new InvalidObjectException("Cannot deserialize CompressedEdwardsY from no data");
     }
 
     /**

--- a/src/main/java/cafe/cryptography/curve25519/CompressedRistretto.java
+++ b/src/main/java/cafe/cryptography/curve25519/CompressedRistretto.java
@@ -12,7 +12,6 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.ObjectStreamException;
 import java.io.Serializable;
-import java.lang.reflect.Field;
 import java.util.Arrays;
 
 import cafe.cryptography.subtle.ConstantTime;
@@ -29,7 +28,7 @@ public class CompressedRistretto implements Serializable {
     /**
      * The encoded point.
      */
-    private transient final byte[] data;
+    private transient byte[] data;
 
     public CompressedRistretto(byte[] data) {
         if (data.length != 32) {
@@ -51,26 +50,7 @@ public class CompressedRistretto implements Serializable {
     private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
         byte[] encoded = new byte[32];
         in.readFully(encoded);
-
-        // CompressedRistretto fields are all final, so we need to carefully set them.
-        Field fieldData = null;
-        try {
-            fieldData = CompressedRistretto.class.getDeclaredField("data");
-            fieldData.setAccessible(true);
-            fieldData.set(this, encoded);
-        } catch (NoSuchFieldException nsfe) {
-            // Should never occur, but just in case...
-            throw new IOException(nsfe);
-        } catch (IllegalAccessException iae) {
-            // Could occur if a SecurityManager is enabled.
-            throw new IOException(iae);
-        } finally {
-            // Ensure the fields are always set back to final if there is a chance
-            // they might have been made accessible.
-            if (fieldData != null) {
-                fieldData.setAccessible(false);
-            }
-        }
+        this.data = encoded;
     }
 
     @SuppressWarnings("unused")

--- a/src/main/java/cafe/cryptography/curve25519/EdwardsPoint.java
+++ b/src/main/java/cafe/cryptography/curve25519/EdwardsPoint.java
@@ -12,7 +12,6 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.ObjectStreamException;
 import java.io.Serializable;
-import java.lang.reflect.Field;
 
 /**
  * An EdwardsPoint represents a point on the Edwards form of Curve25519.
@@ -23,10 +22,10 @@ public class EdwardsPoint implements Serializable {
     public static final EdwardsPoint IDENTITY = new EdwardsPoint(FieldElement.ZERO, FieldElement.ONE, FieldElement.ONE,
             FieldElement.ZERO);
 
-    transient final FieldElement X;
-    transient final FieldElement Y;
-    transient final FieldElement Z;
-    transient final FieldElement T;
+    transient FieldElement X;
+    transient FieldElement Y;
+    transient FieldElement Z;
+    transient FieldElement T;
 
     /**
      * Only for internal use.
@@ -54,49 +53,10 @@ public class EdwardsPoint implements Serializable {
 
         try {
             EdwardsPoint point = new CompressedEdwardsY(encoded).decompress();
-
-            // EdwardsPoint fields are all final, so we need to carefully set them.
-            Field fieldX = null;
-            Field fieldY = null;
-            Field fieldZ = null;
-            Field fieldT = null;
-            try {
-                fieldX = EdwardsPoint.class.getDeclaredField("X");
-                fieldY = EdwardsPoint.class.getDeclaredField("Y");
-                fieldZ = EdwardsPoint.class.getDeclaredField("Z");
-                fieldT = EdwardsPoint.class.getDeclaredField("T");
-
-                fieldX.setAccessible(true);
-                fieldY.setAccessible(true);
-                fieldZ.setAccessible(true);
-                fieldT.setAccessible(true);
-
-                fieldX.set(this, point.X);
-                fieldY.set(this, point.Y);
-                fieldZ.set(this, point.Z);
-                fieldT.set(this, point.T);
-            } catch (NoSuchFieldException nsfe) {
-                // Should never occur, but just in case...
-                throw new IOException(nsfe);
-            } catch (IllegalAccessException iae) {
-                // Could occur if a SecurityManager is enabled.
-                throw new IOException(iae);
-            } finally {
-                // Ensure the fields are always set back to final if there is a chance
-                // they might have been made accessible.
-                if (fieldX != null) {
-                    fieldX.setAccessible(false);
-                }
-                if (fieldY != null) {
-                    fieldY.setAccessible(false);
-                }
-                if (fieldZ != null) {
-                    fieldZ.setAccessible(false);
-                }
-                if (fieldT != null) {
-                    fieldT.setAccessible(false);
-                }
-            }
+            this.X = point.X;
+            this.Y = point.Y;
+            this.Z = point.Z;
+            this.T = point.T;
         } catch (InvalidEncodingException iee) {
             throw new InvalidObjectException(iee.getMessage());
         }

--- a/src/main/java/cafe/cryptography/curve25519/RistrettoElement.java
+++ b/src/main/java/cafe/cryptography/curve25519/RistrettoElement.java
@@ -12,7 +12,6 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.ObjectStreamException;
 import java.io.Serializable;
-import java.lang.reflect.Field;
 import java.util.Arrays;
 
 /**
@@ -26,7 +25,7 @@ public class RistrettoElement implements Serializable {
     /**
      * The internal representation. Not canonical.
      */
-    transient final EdwardsPoint repr;
+    transient EdwardsPoint repr;
 
     /**
      * Only for internal use.
@@ -51,26 +50,7 @@ public class RistrettoElement implements Serializable {
 
         try {
             RistrettoElement elem = new CompressedRistretto(encoded).decompress();
-
-            // RistrettoElement fields are all final, so we need to carefully set them.
-            Field fieldRepr = null;
-            try {
-                fieldRepr = RistrettoElement.class.getDeclaredField("repr");
-                fieldRepr.setAccessible(true);
-                fieldRepr.set(this, elem.repr);
-            } catch (NoSuchFieldException nsfe) {
-                // Should never occur, but just in case...
-                throw new IOException(nsfe);
-            } catch (IllegalAccessException iae) {
-                // Could occur if a SecurityManager is enabled.
-                throw new IOException(iae);
-            } finally {
-                // Ensure the fields are always set back to final if there is a chance
-                // they might have been made accessible.
-                if (fieldRepr != null) {
-                    fieldRepr.setAccessible(false);
-                }
-            }
+            this.repr = elem.repr;
         } catch (InvalidEncodingException iee) {
             throw new InvalidObjectException(iee.getMessage());
         }

--- a/src/main/java/cafe/cryptography/curve25519/RistrettoElement.java
+++ b/src/main/java/cafe/cryptography/curve25519/RistrettoElement.java
@@ -6,18 +6,27 @@
 
 package cafe.cryptography.curve25519;
 
+import java.io.IOException;
+import java.io.InvalidObjectException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.ObjectStreamException;
+import java.io.Serializable;
+import java.lang.reflect.Field;
 import java.util.Arrays;
 
 /**
  * An element of the prime-order ristretto255 group.
  */
-public class RistrettoElement {
+public class RistrettoElement implements Serializable {
+    private static final long serialVersionUID = 1L;
+
     public static final RistrettoElement IDENTITY = new RistrettoElement(EdwardsPoint.IDENTITY);
 
     /**
      * The internal representation. Not canonical.
      */
-    final EdwardsPoint repr;
+    transient final EdwardsPoint repr;
 
     /**
      * Only for internal use.
@@ -27,12 +36,59 @@ public class RistrettoElement {
     }
 
     /**
+     * Overrides class serialization to use the canonical encoded format.
+     */
+    private void writeObject(ObjectOutputStream out) throws IOException {
+        out.write(this.compress().toByteArray());
+    }
+
+    /**
+     * Overrides class serialization to use the canonical encoded format.
+     */
+    private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
+        byte[] encoded = new byte[32];
+        in.readFully(encoded);
+
+        try {
+            RistrettoElement elem = new CompressedRistretto(encoded).decompress();
+
+            // RistrettoElement fields are all final, so we need to carefully set them.
+            Field fieldRepr = null;
+            try {
+                fieldRepr = RistrettoElement.class.getDeclaredField("repr");
+                fieldRepr.setAccessible(true);
+                fieldRepr.set(this, elem.repr);
+            } catch (NoSuchFieldException nsfe) {
+                // Should never occur, but just in case...
+                throw new IOException(nsfe);
+            } catch (IllegalAccessException iae) {
+                // Could occur if a SecurityManager is enabled.
+                throw new IOException(iae);
+            } finally {
+                // Ensure the fields are always set back to final if there is a chance
+                // they might have been made accessible.
+                if (fieldRepr != null) {
+                    fieldRepr.setAccessible(false);
+                }
+            }
+        } catch (InvalidEncodingException iee) {
+            throw new InvalidObjectException(iee.getMessage());
+        }
+    }
+
+    @SuppressWarnings("unused")
+    private void readObjectNoData() throws ObjectStreamException {
+        throw new InvalidObjectException("Cannot deserialize RistrettoElement from no data");
+    }
+
+    /**
      * The function MAP(t) from section 3.2.4 of the ristretto255 ID.
      */
     static RistrettoElement map(final FieldElement t) {
         final FieldElement r = t.square().multiply(Constants.SQRT_M1);
         final FieldElement u = r.add(FieldElement.ONE).multiply(Constants.ONE_MINUS_D_SQ);
-        final FieldElement v = FieldElement.MINUS_ONE.subtract(r.multiply(Constants.EDWARDS_D)).multiply(r.add(Constants.EDWARDS_D));
+        final FieldElement v = FieldElement.MINUS_ONE.subtract(r.multiply(Constants.EDWARDS_D))
+                .multiply(r.add(Constants.EDWARDS_D));
 
         final FieldElement.SqrtRatioM1Result sqrt = FieldElement.sqrtRatioM1(u, v);
         FieldElement s = sqrt.result;
@@ -62,12 +118,12 @@ public class RistrettoElement {
      */
     public static RistrettoElement fromUniformBytes(final byte[] b) {
         // 1. Interpret the low 255 bits of b[ 0..32] as an integer r0 in
-        //    little-endian representation. Reduce r0 modulo p.
+        // little-endian representation. Reduce r0 modulo p.
         final byte[] b0 = Arrays.copyOfRange(b, 0, 32);
         final FieldElement r0 = FieldElement.fromByteArray(b0);
 
         // 2. Interpret the low 255 bits of b[32..64] as an integer r1 in
-        //    little-endian representation. Reduce r1 modulo p.
+        // little-endian representation. Reduce r1 modulo p.
         final byte[] b1 = Arrays.copyOfRange(b, 32, 64);
         final FieldElement r1 = FieldElement.fromByteArray(b1);
 

--- a/src/main/java/cafe/cryptography/curve25519/Scalar.java
+++ b/src/main/java/cafe/cryptography/curve25519/Scalar.java
@@ -12,7 +12,6 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.ObjectStreamException;
 import java.io.Serializable;
-import java.lang.reflect.Field;
 import java.util.Arrays;
 
 import cafe.cryptography.subtle.ConstantTime;
@@ -38,7 +37,7 @@ public class Scalar implements Serializable {
      * <p>
      * Invariant: the highest bit must be zero ($s[31] \le 127$).
      */
-    private transient final byte[] s;
+    private transient byte[] s;
 
     Scalar(byte[] s) {
         if (s.length != 32 || (((s[31] >> 7) & 0x01) != 0)) {
@@ -64,26 +63,7 @@ public class Scalar implements Serializable {
         if (((scalar[31] >> 7) & 0x01) != 0) {
             throw new InvalidObjectException("Invalid scalar representation");
         }
-
-        // Scalar fields are all final, so we need to carefully set them.
-        Field fieldS = null;
-        try {
-            fieldS = Scalar.class.getDeclaredField("s");
-            fieldS.setAccessible(true);
-            fieldS.set(this, scalar);
-        } catch (NoSuchFieldException nsfe) {
-            // Should never occur, but just in case...
-            throw new IOException(nsfe);
-        } catch (IllegalAccessException iae) {
-            // Could occur if a SecurityManager is enabled.
-            throw new IOException(iae);
-        } finally {
-            // Ensure the fields are always set back to final if there is a chance
-            // they might have been made accessible.
-            if (fieldS != null) {
-                fieldS.setAccessible(false);
-            }
-        }
+        this.s = scalar;
     }
 
     @SuppressWarnings("unused")

--- a/src/test/java/cafe/cryptography/curve25519/CompressedEdwardsYTest.java
+++ b/src/test/java/cafe/cryptography/curve25519/CompressedEdwardsYTest.java
@@ -18,34 +18,34 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 
-public class CompressedRistrettoTest {
+public class CompressedEdwardsYTest {
     @Test
     public void constructorDoesNotThrowOnCorrectLength() {
-        new CompressedRistretto(new byte[32]);
+        new CompressedEdwardsY(new byte[32]);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void constructorThrowsOnTooShort() {
-        new CompressedRistretto(new byte[31]);
+        new CompressedEdwardsY(new byte[31]);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void constructorThrowsOnTooLong() {
-        new CompressedRistretto(new byte[33]);
+        new CompressedEdwardsY(new byte[33]);
     }
 
     @Test
     public void serializeDeserialize() throws IOException, ClassNotFoundException {
         byte[] s = new byte[32];
         s[0] = 0x1f;
-        CompressedRistretto expected = new CompressedRistretto(s);
+        CompressedEdwardsY expected = new CompressedEdwardsY(s);
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         ObjectOutputStream oos = new ObjectOutputStream(baos);
         oos.writeObject(expected);
         oos.close();
         ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
         ObjectInputStream ois = new ObjectInputStream(bais);
-        CompressedRistretto actual = (CompressedRistretto) ois.readObject();
+        CompressedEdwardsY actual = (CompressedEdwardsY) ois.readObject();
         assertThat(actual, is(expected));
     }
 
@@ -53,14 +53,6 @@ public class CompressedRistrettoTest {
     public void toByteArray() {
         byte[] s = new byte[32];
         s[0] = 0x1f;
-        assertThat(new CompressedRistretto(s).toByteArray(), is(s));
-    }
-
-    @Test
-    public void equalityRequiresSameClass() {
-        byte[] s = new byte[32];
-        CompressedRistretto r = new CompressedRistretto(s);
-        CompressedEdwardsY e = new CompressedEdwardsY(s);
-        assertFalse(r.equals(e));
+        assertThat(new CompressedEdwardsY(s).toByteArray(), is(s));
     }
 }

--- a/src/test/java/cafe/cryptography/curve25519/EdwardsPointTest.java
+++ b/src/test/java/cafe/cryptography/curve25519/EdwardsPointTest.java
@@ -6,6 +6,12 @@
 
 package cafe.cryptography.curve25519;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+
 import org.junit.*;
 
 import static org.hamcrest.Matchers.is;
@@ -88,6 +94,18 @@ public class EdwardsPointTest {
     public void basepointDecompressionCompression() throws InvalidEncodingException {
         EdwardsPoint B = ED25519_BASEPOINT_COMPRESSED.decompress();
         assertThat(B.compress(), is(ED25519_BASEPOINT_COMPRESSED));
+    }
+
+    @Test
+    public void basepointSerializeDeserialize() throws IOException, ClassNotFoundException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        ObjectOutputStream oos = new ObjectOutputStream(baos);
+        oos.writeObject(Constants.ED25519_BASEPOINT);
+        oos.close();
+        ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
+        ObjectInputStream ois = new ObjectInputStream(bais);
+        EdwardsPoint B = (EdwardsPoint) ois.readObject();
+        assertThat(B, is(Constants.ED25519_BASEPOINT));
     }
 
     @Test

--- a/src/test/java/cafe/cryptography/curve25519/RistrettoElementTest.java
+++ b/src/test/java/cafe/cryptography/curve25519/RistrettoElementTest.java
@@ -6,6 +6,12 @@
 
 package cafe.cryptography.curve25519;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+
 import org.junit.*;
 
 import static org.hamcrest.Matchers.is;
@@ -98,6 +104,18 @@ public class RistrettoElementTest {
         RistrettoElement B = RISTRETTO_GENERATOR_COMPRESSED.decompress();
         assertThat(B, is(Constants.RISTRETTO_GENERATOR));
         assertThat(B.compress(), is(RISTRETTO_GENERATOR_COMPRESSED));
+    }
+
+    @Test
+    public void generatorSerializeDeserialize() throws IOException, ClassNotFoundException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        ObjectOutputStream oos = new ObjectOutputStream(baos);
+        oos.writeObject(Constants.RISTRETTO_GENERATOR);
+        oos.close();
+        ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
+        ObjectInputStream ois = new ObjectInputStream(bais);
+        RistrettoElement B = (RistrettoElement) ois.readObject();
+        assertThat(B, is(Constants.RISTRETTO_GENERATOR));
     }
 
     @Test

--- a/src/test/java/cafe/cryptography/curve25519/ScalarTest.java
+++ b/src/test/java/cafe/cryptography/curve25519/ScalarTest.java
@@ -6,6 +6,12 @@
 
 package cafe.cryptography.curve25519;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+
 import org.junit.*;
 import org.junit.rules.ExpectedException;
 
@@ -89,6 +95,18 @@ public class ScalarTest {
     @Test(expected = IllegalArgumentException.class)
     public void packageConstructorThrowsOnTooLong() {
         new Scalar(new byte[33]);
+    }
+
+    @Test
+    public void serializeDeserialize() throws IOException, ClassNotFoundException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        ObjectOutputStream oos = new ObjectOutputStream(baos);
+        oos.writeObject(X);
+        oos.close();
+        ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
+        ObjectInputStream ois = new ObjectInputStream(bais);
+        Scalar s = (Scalar) ois.readObject();
+        assertThat(s, is(X));
     }
 
     @Test


### PR DESCRIPTION
This enables instances to be contained in classes that implement `Serializable`, such as in key material for signature schemes.