### PR TITLE
Travis CI: Use Trusty build environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: java
+dist: trusty
 
 jdk:
   - oraclejdk11


### PR DESCRIPTION
Travis CI recently bumped the default build environment from Trusty to
Xenial. The latter does not enable installing Java 7 or 8, which we
still test against.